### PR TITLE
parler-py-api additions: review user posts and comments, optionally delete expired items

### DIFF
--- a/Parler/__init__.py
+++ b/Parler/__init__.py
@@ -132,8 +132,8 @@ class Parler:
         return response.json()
 
     """
-    :param item_type: type of items created ('post' or 'comment')
-    :param username: username to get posts
+    :param item_type: type of created items to list ('post' or 'comment')
+    :param username: username to get posts or comments
     :param limit: limit
     :param cursor: string to id the next items
     """

--- a/Parler/__init__.py
+++ b/Parler/__init__.py
@@ -20,7 +20,7 @@ class Parler:
         }
         response = requests.post("https://api.parler.com/v2/login/new", data=json.dumps(data))
         return response.json()
-    
+
     @staticmethod
     def get_chapta_image(key):
         data = {
@@ -39,7 +39,7 @@ class Parler:
 
         response = requests.post("https://api.parler.com/v2/login/captcha/submit",data=json.dumps(data))
         return response.json()
-        
+
     """
     :param jst: short-term token
     :param mst: master token
@@ -55,39 +55,37 @@ class Parler:
         self.session.cookies.set("mst", mst)
         self.session.cookies.set("jst", jst)
         self.reconnects = 0
-        self.retry_delay = 5
+        self.retry_delay = 2
 
         logging.basicConfig(level=logging.DEBUG if self.debug else logging.ERROR)
 
-        
     """
     @helper response handler
     pass an http response through to check for specific codes
     """
-    
     def handle_response(self,response):
         if self.reconnects >= 10:
             raise Exception ("Internal abort; 10 reconnect attemps")
         elif response.status_code >=400 and response.status_code <=428:
             raise Exception ({"status":response.status_code,
                               "error":response.reason,
-                             "message": Errors.NoAuth})
-            
+                             "message": self.Errors.NoAuth})
+
         elif response.status_code == 502:
             logging.warning(f"Bad Gateway Error, retry in {self.retry_delay} seconds")
             self.reconnects += 1
             sleep(self.retry_delay)
 
         elif response.status_code == 429:
-            logging.warning(f"Too many requests Error, retry in {self.retry_delay} x10 seconds")
+            logging.warning(f"Too many requests Error, retry in {self.retry_delay} seconds")
             self.reconnects += 1
-            sleep({self.retry_delay} * 10)
+            sleep(self.retry_delay)
 
         else:
             self.reconnects = 0
 
         return response
-        
+
     """
     :param username: Username to fetch
     """
@@ -132,7 +130,42 @@ class Parler:
             logging.warning(f"Status: {response.status_code}")
             return self.feed(limit,cursor)
         return response.json()
-        
+
+    """
+    :param item_type: type of items created ('post' or 'comment')
+    :param username: username to get posts
+    :param limit: limit
+    :param cursor: string to id the next items
+    """
+    def created_items(self, item_type="post", username="", limit=10, cursor="") -> dict:
+        params = (
+            ("username", username),
+            ("limit", limit)
+        )
+        if cursor != "":
+            params = params + (("startkey",cursor),)
+        response = self.session.get(self.base_url + "/" + item_type + "/creator",  params=params)
+        if self.handle_response(response).status_code != 200:
+            logging.warning(f"Status: {response.status_code}")
+            return self.hashtags(searchtag)
+        return response.json()
+
+
+    """
+    :param item_type: type of item to delete ('post' or 'comment')
+    :param id: id of item to delete
+    """
+    def delete_item(self, item_type, id):
+        if item_type == 'echo':  # delete echo using post api
+            item_type = 'post'
+        params = (
+            ("id", id),
+        )
+        response = self.session.post(self.base_url + "/" + item_type + "/delete", params=params)
+        if self.handle_response(response).status_code != 200:
+            logging.warning(f"Status: {response.status_code}")
+        return response.json()
+
     """
     :param limit: limit
     :param cursor: string to id the next items

--- a/Parler/models.py
+++ b/Parler/models.py
@@ -1,4 +1,5 @@
 from marshmallow import Schema, fields, ValidationError, post_load, EXCLUDE
+import json
 
 
 class UserItem(Schema):
@@ -13,7 +14,7 @@ class UserItem(Schema):
     Muted = fields.Bool(data_key="muted")
     Name = fields.Str(data_key="name")
     Rss = fields.Bool(data_key="rss")
-    Private = fields.Bool(data_key="private")
+    Private = fields.Bool(data_key="private", allow_none=True)
     ProfilePhoto = fields.Str(data_key="profilePhoto")
     Username = fields.Str(data_key="username")
     Verified = fields.Bool(data_key="verified")
@@ -29,24 +30,36 @@ class PostItem(Schema):
     At = fields.Dict(data_key="@")
     Article = fields.Bool(data_key="article")
     Body = fields.String(data_key="body")
+    Color = fields.String(data_key="color")
+    CommentDepth = fields.Int(data_key="commentDepth")
+    Commented = fields.Bool(data_key="commented")
     Comments = fields.String(data_key="comments")
+    Controversy = fields.Int(data_key="controversy")
+    Conversation = fields.String(data_key="conversation")
     CreatedAt = fields.String(data_key="createdAt")
     Creator = fields.String(data_key="creator")
     Depth = fields.String(data_key="depth")
     DepthRaw = fields.Int(data_key="depthRaw")
+    Downvotes = fields.String(data_key="downvotes")
     Hashtags = fields.List(fields.String(),   data_key="hashtags")
     Impressions = fields.String(data_key="impressions")
+    IsPrimary = fields.Bool(data_key="isPrimary")
     Links = fields.List(fields.String(),   data_key="links")
+    Parent = fields.String(data_key="parent")
+    Post = fields.String(data_key="post")
     Preview = fields.String(data_key="preview")
+    ReplyingTo = fields.String(data_key="replyingTo")
+    Reposted = fields.Bool(data_key="reposted")
     Reposts = fields.String(data_key="reposts")
     ShareLink = fields.String(data_key="shareLink")
     State = fields.Int(data_key="state")
     Upvotes = fields.String(data_key="upvotes")
     Parent = fields.String(data_key="parent")
+    Score = fields.String(data_key="score")
     Sponsored = fields.String(data_key="sponsored")
     Sensitive = fields.Bool(data_key="sensitive")
     Root = fields.String(data_key="root")
-
+    Voted = fields.String(data_key="voted")
 
 class LinkItem(Schema):
     Id = fields.String(data_key="_id")
@@ -74,22 +87,27 @@ class Feed():
 
 
 class FeedSchema(Schema):
+    """For newsfeed, user posts, or user comments."""
     Badge = fields.Int(data_key="badge")
     BadgeString = fields.String(data_key="badgeString")
     Last = fields.Bool(data_key="last")
     Next = fields.String(data_key="next")
     PendingFollowers = fields.Int(data_key="pendingFollowers")
     Prev = fields.String(data_key="prev")
-
     Items = fields.List(fields.Nested(PostItem), data_key="posts")
-    Users = fields.List(fields.Nested(UserItem), data_key="users")
-    Links = fields.List(fields.Nested(LinkItem), data_key="urls")
+    Comments = fields.List(fields.Nested(PostItem), data_key="comments")
+    Users = fields.List(fields.Nested(UserItem), data_key="users", allow_none=True)
+    Links = fields.List(fields.Nested(LinkItem), data_key="urls", allow_none=True)
 
     class Meta:
         unknown = EXCLUDE
 
     @post_load
     def make_feed(self, data, **kwargs):
+        # print(json.dumps(data, indent=1))
+        if "Comments" in data.keys():
+            data["Items"] = data["Comments"].copy()
+            del data["Comments"]
         return Feed(**data)
 
 class UserList():

--- a/parleruser.py
+++ b/parleruser.py
@@ -1,0 +1,80 @@
+"""Delete posts and comments created before expiration deadline."""
+import json
+import os
+import time
+import traceback
+from datetime import datetime, timedelta
+from dotenv import load_dotenv
+from termcolor import colored
+from Parler import Parler, models
+
+load_dotenv(dotenv_path=".parler.env")
+parler = Parler(jst=os.getenv("JST"), mst=os.getenv("MST"), debug=False)
+
+
+def process_item(item_type, item, expiration, delete_active):
+    """Delete expired item if expired, then print item report."""
+    # print(json.dumps(item, indent=1))
+    time_since = datetime.utcnow() - datetime.strptime(item.get("CreatedAt"),
+                                                       "%Y%m%d%H%M%S")
+    if expiration and time_since > timedelta(days=float(expiration)):
+        date_color = "red"
+        deletion_msg = " ***DELETING*** "
+        if delete_active:
+            try:
+                deletion_msg += parler.delete_item(item_type,
+                                                   item.get("Id"))["message"]
+            except Exception as e:
+                deletion_msg += e.args[0]['error']
+        else:
+            deletion_msg += "Dry run"
+    else:
+        date_color = "green"
+        deletion_msg = ""
+    if item_type == "post":
+        body_color = "blue"
+    else:
+        body_color = "yellow"
+    print("\t", colored(item.get("Id"), "cyan"))
+    print(
+        "\t>>> Created:",
+        colored(
+            item.get("CreatedAt") + " (" + str(time_since) + ")" +
+            deletion_msg, date_color))
+    print("\t>>>",
+          item_type.capitalize() + ":",
+          colored(item.get("Body").replace("\n", " "), body_color))
+
+
+def user_items(username, expiration=None, delete_active=False):
+    """Retrieve posts and comments created by username."""
+    for item_type in ['post', 'comment']:
+        data = parler.created_items(item_type, username, limit=100, cursor="")
+        if len(data[item_type + 's']) == 0:
+            break  # skip processing if no posts/comments
+        feed = models.FeedSchema().load(data)
+        count = 0
+        while count < 20:
+            try:
+                for item in feed.items:
+                    process_item(item_type, item, expiration, delete_active)
+                if feed.last:
+                    break
+                more_items = feed.next
+                data = parler.created_items(item_type,
+                                            username,
+                                            limit=100,
+                                            cursor=more_items)
+                feed = models.FeedSchema().load(data)
+                count += 1
+            except:
+                traceback.print_exc()
+                time.sleep(5)
+            finally:
+                time.sleep(1)
+
+
+if __name__ == '__main__':
+    username = os.getenv("USERNAME")  # display name
+    expiration = os.getenv("EXPIRATION")  # days, may be fractional
+    user_items(username, expiration)


### PR DESCRIPTION
Konrad,

Thank you for posting your useful Parler API. I adapted it for another task: reviewing the posts and comments of an account, and potentially deleting items that have expired (posted prior to N days ago).

`parleruser.py` cam browse any public account, but obviously can only delete items from an account for which the credentials match. A boolean "safety" is provided to allow expiration dry run before actually deleting. Username and expiration are added to the .parler.env file.

Thought you might find some of this useful, or perhaps someone else who comes across your code, since it's the best (only?) Python API for Parler out there I've found. Hence this pull request, which you can adopt or not as you see fit.

Lots of manual testing using Python 3.7.8. As with any form of reverse engineering, the secret mysteries of the Parler API may cause unexpected exceptions.

Please drop a line if you have any questions. And again, thank you for posting your really solid foundation.

Regards,
Larry

P.S. Even if you decide not to pull all the code, you might want to fix the bug in handle_response. I believe:
`"message": Errors.NoAuth})`
should be
`"message": self.Errors.NoAuth})`