### PR TITLE
Fix installation of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,13 @@
 
 import setuptools
 import pathlib
-from Parler.version import version
+version = open("Parler/version.py").read().split('"')[1]
 
 pwd = pathlib.Path(__file__).parent
 description = (pwd / "README.md").read_text()
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 setuptools.setup(
     name="parler-api",
@@ -18,5 +21,5 @@ setuptools.setup(
     author_email="mail@chernowii.com",
     packages=setuptools.find_packages(),
     python_requires=">=3.6",
-    install_requires=["requests", "marshmallow"],
+    install_requires=requirements,
 )


### PR DESCRIPTION
Hi Konrad,

In https://github.com/KonradIT/parler-py-api/pull/21, I fixed a bug that prevented using the package from other working directories. Unfortunately, this appears to have introduced a different bug, which is that you can't install the package (with operations like `pip install .` or `pip install https://github.com/KonradIT/parler-py-api/archive/refs/heads/v2.zip`) unless you first have the dependencies installed. This appears to be caused by Python executing the `__init__.py` file, before executing the `version.py` file. Sample stacktrace:

```python
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/nyou045/git/parler-py-api/setup.py", line 5, in <module>
          from Parler.version import version
        File "/home/nyou045/git/parler-py-api/Parler/__init__.py", line 1, in <module>
          import requests
      ModuleNotFoundError: No module named 'requests'
```

This is easiest to see in a fresh virtualenv. This PR fixes this issue by reading version.py manually, instead of trying to import it.
Additionally, it seemed that only requests and marshmallow were being installed, so I've updated setup.py to read requirements.txt.